### PR TITLE
retry on json errors

### DIFF
--- a/conjure/controllers/finish.py
+++ b/conjure/controllers/finish.py
@@ -145,7 +145,14 @@ class FinishController:
 
     def _post_exec_done(self, future):
         try:
-            result = json.loads(future.result().decode('utf8'))
+            fr = future.result().decode('utf8')
+            try:
+                result = json.loads(fr)
+            except json.decoder.JSONDecodeError:
+                result = dict(returnCode=1, fr=fr,
+                              jsonError=True,
+                              message="Retrying post-processing.")
+
             self.app.log.debug("post_exec_done: {}".format(result))
             self.app.ui.set_footer(result['message'])
             if result['returnCode'] > 0 or not result['isComplete']:


### PR DESCRIPTION
Judging from the errors we've seen, it's likely to be an empty string.

In case of a json parsing error, just schedule a retry again instead of dying.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>